### PR TITLE
Shorten language codes for Google Translate API

### DIFF
--- a/src/commands/TranslateFilesCommand.php
+++ b/src/commands/TranslateFilesCommand.php
@@ -158,7 +158,7 @@ class TranslateFilesCommand extends Command
      */
     private static function translate_via_api_key($base_locale, $locale, $text){
         $apiKey = config('laravel_google_translate.google_translate_api_key');
-        $url = 'https://www.googleapis.com/language/translate/v2?key=' . $apiKey . '&q=' . rawurlencode($text) . '&source=' . $base_locale . '&target=' . $locale;
+        $url = 'https://www.googleapis.com/language/translate/v2?key=' . $apiKey . '&q=' . rawurlencode($text) . '&source=' . substr($base_locale, 0, 2) . '&target=' . substr($locale, 0, 2);
         $handle = curl_init();
         curl_setopt($handle, CURLOPT_URL, $url);
         curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
Make the API work even if you locally use longer language codes, like en_US, sv_SE.

I don't know if it's considered a good or bad solution, but for me it fixes the API :-) For more info about my problem see issue #7 