### PR TITLE
Translate vendor language files (php)

### DIFF
--- a/src/TranslationFileTranslators/PhpArrayFileTranslator.php
+++ b/src/TranslationFileTranslators/PhpArrayFileTranslator.php
@@ -130,7 +130,7 @@ class PhpArrayFileTranslator implements FileTranslatorContract
         $lang_path          = $this->to_unix_dir_separator(resource_path('lang'));
         $directory_iterator = new \RecursiveDirectoryIterator($lang_path, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::UNIX_PATHS);
         $recursive_iterator = new \RecursiveIteratorIterator($directory_iterator);
-        $regex              = '/^.+\\\\' . $this->base_locale . '\\\\.+\.php$/i';
+        $regex              = '/^.+\/' . $this->base_locale . '\/.+\.php$/i';
         $regex_iterator     = new \RegexIterator($recursive_iterator, $regex, \RecursiveRegexIterator::GET_MATCH);
 
         $files = [];

--- a/src/TranslationFileTranslators/PhpArrayFileTranslator.php
+++ b/src/TranslationFileTranslators/PhpArrayFileTranslator.php
@@ -76,6 +76,11 @@ class PhpArrayFileTranslator implements FileTranslatorContract
     private function write_translations_to_file($target_locale, $file, $translations)
     {
         $target = $this->get_language_file_address($target_locale, $file);
+
+        if (! file_exists(dirname($target))) {
+            mkdir(dirname($target), 0777, true);
+        }
+
         $file   = fopen($target, "w+");
         $export = var_export($translations, true);
 

--- a/src/TranslationFileTranslators/PhpArrayFileTranslator.php
+++ b/src/TranslationFileTranslators/PhpArrayFileTranslator.php
@@ -115,15 +115,18 @@ class PhpArrayFileTranslator implements FileTranslatorContract
                 $dir_content = $folder.'/'.$dir_content;
             }
 
-            if (in_array($this->strip_php_extension($dir_content), $this->excluded_files)) {
+            $file = $this->strip_php_extension($dir_content);
+
+            if (in_array($file, $this->excluded_files)) {
                 continue;
             }
 
             if (is_dir($this->get_language_file_address($this->base_locale, $dir_content))) {
                 $files = array_merge($files, $this->get_translation_files($dir_content));
-            } else {
-                $files[] = $this->strip_php_extension($dir_content);
+                continue;
             }
+
+            $files[] = $file;
         }
 
         return $files;

--- a/src/TranslationFileTranslators/PhpArrayFileTranslator.php
+++ b/src/TranslationFileTranslators/PhpArrayFileTranslator.php
@@ -170,6 +170,11 @@ class PhpArrayFileTranslator implements FileTranslatorContract
 
     // others
 
+    public function to_unix_dir_separator(string $path): string
+    {
+        return str_replace('\\', '/', $path);
+    }
+
     public function setTargetFiles($target_files)
     {
         $this->target_files = $target_files;

--- a/src/TranslationFileTranslators/PhpArrayFileTranslator.php
+++ b/src/TranslationFileTranslators/PhpArrayFileTranslator.php
@@ -105,26 +105,24 @@ class PhpArrayFileTranslator implements FileTranslatorContract
 
         if (count($this->target_files) > 0) {
             return $this->target_files;
+        }
 
-        } else {
+        $files = [];
+        $dir_contents = preg_grep('/^([^.])/', scandir($this->get_language_file_address($this->base_locale, $folder)));
 
-            $files = [];
-            $dir_contents = preg_grep('/^([^.])/', scandir($this->get_language_file_address($this->base_locale, $folder)));
+        foreach ($dir_contents as $dir_content) {
+            if (!is_null($folder)) {
+                $dir_content = $folder.'/'.$dir_content;
+            }
 
-            foreach ($dir_contents as $dir_content) {
-                if (!is_null($folder)) {
-                    $dir_content = $folder.'/'.$dir_content;
-                }
+            if (in_array($this->strip_php_extension($dir_content), $this->excluded_files)) {
+                continue;
+            }
 
-                if (in_array($this->strip_php_extension($dir_content), $this->excluded_files)) {
-                    continue;
-                }
-
-                if (is_dir($this->get_language_file_address($this->base_locale, $dir_content))) {
-                    $files = array_merge($files, $this->get_translation_files($dir_content));
-                } else {
-                    $files[] = $this->strip_php_extension($dir_content);
-                }
+            if (is_dir($this->get_language_file_address($this->base_locale, $dir_content))) {
+                $files = array_merge($files, $this->get_translation_files($dir_content));
+            } else {
+                $files[] = $this->strip_php_extension($dir_content);
             }
         }
 

--- a/src/TranslationFileTranslators/PhpArrayFileTranslator.php
+++ b/src/TranslationFileTranslators/PhpArrayFileTranslator.php
@@ -100,38 +100,26 @@ class PhpArrayFileTranslator implements FileTranslatorContract
         return $filename;
     }
 
-    private function get_translation_files($folder = null)
+    private function get_translation_files()
     {
 
         if (count($this->target_files) > 0) {
             return $this->target_files;
         }
 
+        $lang_path          = $this->to_unix_dir_separator(resource_path('lang'));
+        $directory_iterator = new \RecursiveDirectoryIterator($lang_path);
+        $recursive_iterator = new \RecursiveIteratorIterator($directory_iterator);
+        $regex              = '/^.+\\\\' . $this->base_locale . '\\\\.+\.php$/i';
+        $regex_iterator     = new \RegexIterator($recursive_iterator, $regex, \RecursiveRegexIterator::GET_MATCH);
+
         $files = [];
-        $dir_contents = preg_grep('/^([^.])/', scandir($this->get_language_file_address($this->base_locale, $folder)));
 
-        foreach ($dir_contents as $dir_content) {
-            if (!is_null($folder)) {
-                $dir_content = $folder.'/'.$dir_content;
-            }
-
-            $file = $this->strip_php_extension($dir_content);
-
-            if (in_array($file, $this->excluded_files)) {
-                continue;
-            }
-
-            if (is_dir($this->get_language_file_address($this->base_locale, $dir_content))) {
-                $files = array_merge($files, $this->get_translation_files($dir_content));
-                continue;
-            }
-
-            $files[] = $file;
+        foreach ($regex_iterator as $file_info) {
+            $files[] = $this->to_unix_dir_separator($file_info[0]);
         }
-
         return $files;
     }
-
 
     // in file operations :
 

--- a/src/TranslationFileTranslators/PhpArrayFileTranslator.php
+++ b/src/TranslationFileTranslators/PhpArrayFileTranslator.php
@@ -30,17 +30,21 @@ class PhpArrayFileTranslator implements FileTranslatorContract
         $files = $this->get_translation_files();
         $this->create_missing_target_folders($target_locale, $files);
         foreach ($files as $file) {
+
             $existing_translations = [];
             $group_to_translate = $this->file_to_namespace($file);
             $file_address = $this->get_language_file_address($target_locale, $file);
+
             $this->line($file_address.' is preparing');
             if (file_exists($file_address)) {
                 $this->line('File already exists');
                 $existing_translations = trans($group_to_translate, [], $target_locale);
                 $this->line('Existing translations collected');
             }
+
             $to_be_translateds = trans($group_to_translate, [], $this->base_locale);
             $this->line('Source text collected');
+
             $translations = [];
             if (is_array($to_be_translateds)) {
                 $translations = $this->handleTranslations($to_be_translateds, $existing_translations, $target_locale);

--- a/src/TranslationFileTranslators/PhpArrayFileTranslator.php
+++ b/src/TranslationFileTranslators/PhpArrayFileTranslator.php
@@ -128,7 +128,7 @@ class PhpArrayFileTranslator implements FileTranslatorContract
         }
 
         $lang_path          = $this->to_unix_dir_separator(resource_path('lang'));
-        $directory_iterator = new \RecursiveDirectoryIterator($lang_path);
+        $directory_iterator = new \RecursiveDirectoryIterator($lang_path, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::UNIX_PATHS);
         $recursive_iterator = new \RecursiveIteratorIterator($directory_iterator);
         $regex              = '/^.+\\\\' . $this->base_locale . '\\\\.+\.php$/i';
         $regex_iterator     = new \RegexIterator($recursive_iterator, $regex, \RecursiveRegexIterator::GET_MATCH);

--- a/src/TranslationFileTranslators/PhpArrayFileTranslator.php
+++ b/src/TranslationFileTranslators/PhpArrayFileTranslator.php
@@ -28,7 +28,7 @@ class PhpArrayFileTranslator implements FileTranslatorContract
         $this->create_missing_target_folders($target_locale, $files);
         foreach ($files as $file) {
             $existing_translations = [];
-            $file_address = $this->get_language_file_address($target_locale, $file.'.php');
+            $file_address = $this->get_language_file_address($target_locale, $file . '.php');
             $this->line($file_address.' is preparing');
             if (file_exists($file_address)) {
                 $this->line('File already exists');
@@ -51,20 +51,22 @@ class PhpArrayFileTranslator implements FileTranslatorContract
     private function create_missing_target_folders($target_locale, $files)
     {
         $target_locale_folder = $this->get_language_file_address($target_locale);
-        if(!is_dir($target_locale_folder)){
+        if (! is_dir($target_locale_folder)) {
             mkdir($target_locale_folder);
         }
-        foreach ($files as $file){
-            if(Str::contains($file, '/')){
+
+        foreach ($files as $file) {
+            if (Str::contains($file, '/')) {
                 $folder_address = $this->get_language_file_address($target_locale, dirname($file));
-                if(!is_dir($folder_address)){
+                if (! is_dir($folder_address)) {
                     mkdir($folder_address, 0777, true);
                 }
             }
         }
     }
 
-    private function write_translations_to_file($target_locale, $file, $translations){
+    private function write_translations_to_file($target_locale, $file, $translations)
+    {
         $file = fopen($this->get_language_file_address($target_locale, $file.'.php'), "w+");
         $export = var_export($translations, true);
 
@@ -77,47 +79,55 @@ class PhpArrayFileTranslator implements FileTranslatorContract
         ];
         $export = preg_replace(array_keys($patterns), array_values($patterns), $export);
 
-
         $write_text = "<?php \nreturn " . $export . ";";
         fwrite($file, $write_text);
         fclose($file);
         return 1;
     }
 
-    private function get_language_file_address($locale, $sub_folder = null){
-        return $sub_folder!==null ?
-            resource_path('lang/' . $locale.'/'.$sub_folder) :
+    private function get_language_file_address($locale, $sub_folder = null)
+    {
+        return $sub_folder !== null ?
+            resource_path('lang/' . $locale . '/' . $sub_folder) :
             resource_path('lang/' . $locale);
     }
 
-    private function strip_php_extension($filename){
-        if(substr($filename,-4) === '.php'){
-            $filename = substr($filename,0, -4);
+    private function strip_php_extension($filename)
+    {
+        if (substr($filename, -4) === '.php') {
+            $filename = substr($filename, 0, -4);
         }
         return $filename;
     }
 
-    private function get_translation_files($folder = null){
+    private function get_translation_files($folder = null)
+    {
+
         if (count($this->target_files) > 0) {
-            $files = $this->target_files;
-        }
-        else{
+            return $this->target_files;
+
+        } else {
+
             $files = [];
             $dir_contents = preg_grep('/^([^.])/', scandir($this->get_language_file_address($this->base_locale, $folder)));
-            foreach ($dir_contents as $dir_content){
-                if(!is_null($folder))
+
+            foreach ($dir_contents as $dir_content) {
+                if (!is_null($folder)) {
                     $dir_content = $folder.'/'.$dir_content;
+                }
+
                 if (in_array($this->strip_php_extension($dir_content), $this->excluded_files)) {
                     continue;
                 }
-                if(is_dir($this->get_language_file_address($this->base_locale, $dir_content))){
-                    $files = array_merge($files,$this->get_translation_files($dir_content));
-                }
-                else{
+
+                if (is_dir($this->get_language_file_address($this->base_locale, $dir_content))) {
+                    $files = array_merge($files, $this->get_translation_files($dir_content));
+                } else {
                     $files[] = $this->strip_php_extension($dir_content);
                 }
             }
         }
+
         return $files;
     }
 
@@ -153,6 +163,7 @@ class PhpArrayFileTranslator implements FileTranslatorContract
                 }
             }
         }
+
         return $translations;
     }
 

--- a/tests/Unit/TranslateFilesCommandTest.php
+++ b/tests/Unit/TranslateFilesCommandTest.php
@@ -22,6 +22,10 @@ class TranslateFilesCommandTest extends TestCase
         $this->assertFileExists(resource_path('lang/tr/tests.php'));
         unlink(resource_path('lang/tr/tests.php'));
         rmdir(resource_path('lang/tr'));
+
+        $this->assertFileExists(resource_path('lang/vendor/package/tr/vendor_tests.php'));
+        unlink(resource_path('lang/vendor/package/tr/vendor_tests.php'));
+        rmdir(resource_path('lang/vendor/package/tr'));
     }
 
     public function testTranslateJsonFilesCommand()
@@ -38,4 +42,3 @@ class TranslateFilesCommandTest extends TestCase
         unlink(resource_path('lang/tr.json'));
     }
 }
-

--- a/tests/test-resources/resources/lang/vendor/package/sv/vendor_tests.php
+++ b/tests/test-resources/resources/lang/vendor/package/sv/vendor_tests.php
@@ -1,0 +1,8 @@
+<?php
+return [
+    "text1" => "Tidpunkterna måste vara i formatet hh:mm! ",
+    "text2" => ":name har redan attesterat denna månad!",
+    "text3" => "Detta krockar med en registrering som :name har gjort mellan klockan :from och :to samma dag!",
+    "text4" => "Grattis, du hade rätt på :percent% av frågorna på första försöket!",
+    "text5" => "(Ange :alternatives alternativ)",
+];


### PR DESCRIPTION
This PR enable the translation of php language files under `resource/lang/vendor`.

It modifies some core functions from `PhpArrayFileTranslator.php`:

- All paths are changed to use unix directory separator, so they are consistent on every step of the process
- `get_translation_files` now uses a recursive iterator that gets all files where the path includes a folder named with the base locale (ex: `/en/`). This might be an issue if we have something like this: `/lang/es/weird/en/file.php` but I can't remember to have seen anything like this.
- `get_language_file_address` simply replaces the first occurence of the base locale to the target locale on the file, that allows it to work with `lang/en/...` and also with `lang/vendor/package/en/...`
- `get_language_file_address` now returns the full path of the target file, not only the dirname.
- When looking for translated and source string, we first check if the file is under the `/vendor/` folder and then we use the file path to get the namespaced translation key, and we add the namespace to Laravel's translation app to prevent missing translations from packages that have not been booted or that doesn't register the namespace on it's service provider

I also made some cosmetic changes for better readability.

NOTE: this is only for php lang files. I don't know any package that ships with a json translation file under `/vendor/` so this is missing translating vendor json files. If you know such package, please tell me so I can add a PR for that so the package is consistent.