### PR TITLE
Laravel 11.x Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,8 @@
     }
   ],
   "require-dev": {
-    "phpunit/phpunit": "^8.3",
-    "orchestra/testbench": "5.x-dev|6.x-dev"
+    "phpunit/phpunit": "^10.5",
+    "orchestra/testbench": "5.x-dev|6.x-dev|9.x-dev"
   },
   "minimum-stability": "dev",
   "prefer-stable": true

--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
   "require": {
     "illuminate/console": ">=5.1",
     "php": ">=7.1.0",
-    "illuminate/support": "^5.5|^6|^7|^8|^9|^10",
-    "illuminate/translation": "^5.5|^6|^7|^8|^9|^10",
-    "stichoza/google-translate-php": "^4.0",
+    "illuminate/support": "^5.5|^6|^7|^8|^9|^10|^11",
+    "illuminate/translation": "^5.5|^6|^7|^8|^9|^10|^11",
+    "stichoza/google-translate-php": "^5.0.1",
     "google/cloud-translate": "^1.7.4",
     "yandex/translate-api": "^1.5.2",
     "ext-json": "*"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,16 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/Unit</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
Added compatibility with Laravel 11
Requires stichoza/google-translate-php v5.0.1 to be compatible with PHP 8