### PR TITLE
Clarifying the readme & doc block; Adding output to be sure which translator is running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 .idea/
 docker-compose.yml
+.phpunit.cache/

--- a/README.md
+++ b/README.md
@@ -11,27 +11,29 @@ This package provides two translation methods for Laravel helper Str
 * `Illuminate\Support\Str::apiTranslateWithAttributes` -> Again translates texts using your selected api in config
  in addition to that this function ***respects Laravel translation text attributes*** like :name
  
-## how to use your own translation api
- 
-* Create your own translation api class by implementing Tanmuhittin\LaravelGoogleTranslate\Contracts\ApiTranslatorContract
-* Write your classname in config laravel_google_translate.custom_api_translator . Example : Myclass::class
-* Write your custom apikey for your custom class in laravel_google_translate.custom_api_translator_key
+## How to use your own translation API
+* Create your own translation API class by implementing `Tanmuhittin\LaravelGoogleTranslate\Contracts\ApiTranslatorContract`.
+* Set your classname in `config/laravel_google_translate.php` under the `custom_api_translator` key. 
+* Set your custom API key for your custom class in the `custom_api_translator_key` key in the config file, or ideally in the `CUSTOM_API_TRANSLATOR_KEY` environment variable.
+
+Example:<br>
+_config/laravel_google_translate.php_
+```php
+'custom_api_translator' => env('CUSTOM_API_TRANSLATOR', Myclass::class),
+'custom_api_translator_key' => env('CUSTOM_API_TRANSLATOR_KEY', null),
+```
 
 Now all translations will use your custom api.
 
 ## installation
 ```console
-composer require tanmuhittin/laravel-google-translate
+composer require --dev tanmuhittin/laravel-google-translate
 php artisan vendor:publish --provider="Tanmuhittin\LaravelGoogleTranslate\LaravelGoogleTranslateServiceProvider"
 ```
 
 If you would like to use stichoza/google-translate-php you do not need an API key. If you would like to use Google Translate API, edit config/laravel_google_translate.php and add your Google Translate API key.
 
-```console
-php artisan config:cache
-```
-
-Then you can run
+Then you can run:
 
 ```console
 php artisan translate:files

--- a/src/Contracts/ApiTranslatorContract.php
+++ b/src/Contracts/ApiTranslatorContract.php
@@ -15,9 +15,9 @@ interface ApiTranslatorContract
 
 
     /**
-     * @param string $text
-     * @param string $locale
-     * @param string|null $base_locale
+     * @param string $text The text to be translated
+     * @param string $locale Language into which the text should be translated.
+     * @param string|null $base_locale Language of the source text to be translated. If omitted, some APIs will attempt to detect the source language automatically.
      * @return string
      */
     public function translate(string $text, string $locale, string $base_locale = null): string;

--- a/src/LaravelGoogleTranslateServiceProvider.php
+++ b/src/LaravelGoogleTranslateServiceProvider.php
@@ -41,6 +41,7 @@ class LaravelGoogleTranslateServiceProvider extends ServiceProvider
 
         $this->app->singleton(ApiTranslatorContract::class, function ($app) use ($config) {
             if (isset($config['custom_api_translator']) && $config['custom_api_translator']!==null){
+                echo 'Using your custom API translator', PHP_EOL;
                 $custom_translator = new $config['custom_api_translator']($config['custom_api_translator_key']);
                 if($custom_translator instanceof ApiTranslatorContract)
                     return $custom_translator;
@@ -48,10 +49,13 @@ class LaravelGoogleTranslateServiceProvider extends ServiceProvider
                     throw new \Exception($config['custom_api_translator'].' must implement '.ApiTranslatorContract::class);
             }
             elseif (isset($config['google_translate_api_key']) && $config['google_translate_api_key'] !== null) {
+                echo 'Using Google translator', PHP_EOL;
                 return new GoogleApiTranslate($config['google_translate_api_key']);
             } elseif (isset($config['yandex_translate_api_key']) && $config['yandex_translate_api_key'] !== null) {
+                echo 'Using Yandex translator', PHP_EOL;
                 return new YandexApiTranslate($config['yandex_translate_api_key']);
             } else {
+                echo 'Using Stichoza API translator', PHP_EOL;
                 return new StichozaApiTranslate(null);
             }
         });


### PR DESCRIPTION
Clarifying the readme; Adding verbosity to doc block; adding output statements so we can be sure which translator is being used. Addresses: https://github.com/tanmuhittin/laravel-google-translate/issues/73
