### PR TITLE
Patch 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "php": ">=7.1.0",
     "illuminate/support": "^5.5|^6|^7|^8|^9|^10|^11",
     "illuminate/translation": "^5.5|^6|^7|^8|^9|^10|^11",
-    "stichoza/google-translate-php": "^5.0.1",
+    "stichoza/google-translate-php": "^5.2.0",
     "google/cloud-translate": "^1.7.4",
     "yandex/translate-api": "^1.5.2",
     "ext-json": "*"

--- a/src/Api/StichozaApiTranslate.php
+++ b/src/Api/StichozaApiTranslate.php
@@ -21,14 +21,13 @@ class StichozaApiTranslate implements ApiTranslatorContract
 
     public function translate(string $text, string $locale, string $base_locale = null): string
     {
-        if ($base_locale === null)
-            $this->handle->setSource();
-        else
-            $this->handle->setSource($base_locale);
-        $this->handle->setTarget($locale);
+        $this->handle
+            ->setSource($base_locale)
+            ->setTarget($locale);
+
         try {
             return $this->handle->translate($text);
-        } catch (\ErrorException $e) {
+        } catch (\Exception $e) {
             return false;
         }
     }

--- a/src/Api/StichozaApiTranslate.php
+++ b/src/Api/StichozaApiTranslate.php
@@ -26,7 +26,7 @@ class StichozaApiTranslate implements ApiTranslatorContract
             ->setTarget($locale);
 
         try {
-            return $this->handle->translate($text);
+            return $this->handle->translate($text) ?? '';
         } catch (\Exception $e) {
             return false;
         }


### PR DESCRIPTION
## Changes proposed

- **Bump version from `^5.0.1` to `^5.2.0`.**
No backwards incompatible changes except `ext-dom` was added to requirements, which is [bundled](https://www.php.net/manual/en/extensions.membership.php) with PHP.
- **Remove redundant check of `$base_locale`.**
The `setSource()` method already supports [passing null](https://github.com/Stichoza/google-translate-php?tab=readme-ov-file#basic-usage) as a parameter. So we can just use `setSource($base_locale)` even if the value is `null` (otherwise it will be string as defined in parameter type).
- **Wider exception class**
The `translate()` might throw multiple different exceptions, most of them extend `ErrorException`, but some of them are extending `UnexpectedValueException`. Using `Exception` in catch block to cover all possible situations.
- **Null coalescing operator**
The `translate()` method of my package might return `null`. Returning `null` will cause uncaught `TypeError`. Added null coalescing operator to handle this situation.

## Other

- **Returning `false` from method with return type `string`**
One thing that I didn't change is the `return false` in the catch block. Method has `string` as return type (as defined in `ApiTranslatorContract`). Returning `false` will not cause any errors like in case of null, but it will be converted to an empty string. I'm not sure if it's intended that way so I didn't touch it.