### PR TITLE
Use explicit nullable types because of PHP 8.4 deprecations

### DIFF
--- a/src/LaravelGoogleTranslateServiceProvider.php
+++ b/src/LaravelGoogleTranslateServiceProvider.php
@@ -73,12 +73,12 @@ class LaravelGoogleTranslateServiceProvider extends ServiceProvider
             );
         });
 
-        Str::macro('apiTranslate', function (string $text, string $locale, string $base_locale = null) {
+        Str::macro('apiTranslate', function (string $text, string $locale, ?string $base_locale = null) {
             ConfigHelper::getBaseLocale($base_locale);
             $translator = resolve(ApiTranslate::class);
             return $translator->translate($text, $locale, $base_locale);
         });
-        Str::macro('apiTranslateWithAttributes', function (string $text, string $locale, string $base_locale = null) {
+        Str::macro('apiTranslateWithAttributes', function (string $text, string $locale, ?string $base_locale = null) {
             ConfigHelper::getBaseLocale($base_locale);
             $translator = resolve(ApiTranslateWithAttribute::class);
             return $translator->translateWithAttributes($text, $locale, $base_locale);


### PR DESCRIPTION
In PHP 8.4 parameters being defined as implicitly null are deprecated: ([RFC for reference](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types))

Your lowest supported version is 7.1 - which has nullable types.

This PR replaces two implicit nullable types with explicit nullable types